### PR TITLE
Update plugin info to match commit date.

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   diffpreview
 author Mikhail I. Izmestev
 email  izmmishao5@gmail.com
-date   2011-01-20
+date   2014-07-16
 name   diffpreview
 desc   add diff preview
 url    http://dokuwiki.org/plugin:diffpreview


### PR DESCRIPTION
Dokuwiki shows this plugin as needing an update despite being up to date. I think this should fix this.